### PR TITLE
Updated to use installer for v2.3.21

### DIFF
--- a/fusioninventory-agent.install/fusioninventory-agent.install.nuspec
+++ b/fusioninventory-agent.install/fusioninventory-agent.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent.install</id>
     <title>FusionInventory Agent (Install)</title>
-    <version>2.3.20</version>
+    <version>2.3.21</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/fusinv/fusioninventory-agent/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent.install/fusioninventory-agent-logo.png</iconUrl>
-    <releaseNotes>http://fusioninventory.org/2017/06/02/fusioninventory-agent-2.3.20.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2017/08/01/fusioninventory-agent-2.3.21.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>

--- a/fusioninventory-agent.install/tools/chocolateyInstall.ps1
+++ b/fusioninventory-agent.install/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
 $packageInstallArgs = @{
     packageName    = 'fusioninventory-agent.install'
     fileType       = 'exe'
-    url            = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.3.20/fusioninventory-agent_windows-x86_2.3.20.exe'
-    url64bit       = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.3.20/fusioninventory-agent_windows-x64_2.3.20.exe'
+    url            = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.3.21/fusioninventory-agent_windows-x86_2.3.21.exe'
+    url64bit       = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.3.21/fusioninventory-agent_windows-x64_2.3.21.exe'
     silentArgs     = '/S /acceptlicense'
     validExitCodes = @(0)
-    checksum       = '9db73ac8aa779902219b13e834ec95009f6ac0015e743dfac1de52b6e6777a2c'
+    checksum       = '08de922e012bec687f7671bba38906fd024e80e63d593fc39c59e75b57e1a84d'
     checksumType   = 'sha256'
-    checksum64     = '20318a1ee5f3e2a61aa927b5c44032cf032d27dbcbc3e27b86ba2e51d7b96785'
+    checksum64     = '302dfa9b6108cf093c0d290b1dabebb328142d6e57c3bfee2b14c835d85afbd0'
     checksumType64 = 'sha256'
 }
 

--- a/fusioninventory-agent.portable/fusioninventory-agent.portable.nuspec
+++ b/fusioninventory-agent.portable/fusioninventory-agent.portable.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent.portable</id>
     <title>FusionInventory Agent (Portable)</title>
-    <version>2.3.20</version>
+    <version>2.3.21</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/fusinv/fusioninventory-agent/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent.portable/fusioninventory-agent-logo.png</iconUrl>
-    <releaseNotes>http://fusioninventory.org/2017/06/02/fusioninventory-agent-2.3.20.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2017/08/01/fusioninventory-agent-2.3.21.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>

--- a/fusioninventory-agent.portable/tools/chocolateyInstall.ps1
+++ b/fusioninventory-agent.portable/tools/chocolateyInstall.ps1
@@ -2,11 +2,11 @@ $packageName = 'fusioninventory-agent.portable'
 
 $packageDownloadArgs = @{
     packageName = $packageName
-    url         = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.3.20/fusioninventory-agent_windows-x86_2.3.20-portable.exe' # NB: Theses EXE are 7z SFX
-    url64bit    = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.3.20/fusioninventory-agent_windows-x64_2.3.20-portable.exe'
-    checksum       = '4ecb8770a03a28302cdcf865189aa65de291547921dd7ed633df6c2babc1a6da'
+    url         = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.3.21/fusioninventory-agent_windows-x86_2.3.21-portable.exee' # NB: Theses EXE are 7z SFX
+    url64bit    = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.3.21/fusioninventory-agent_windows-x64_2.3.21-portable.exe'
+    checksum       = '586a2e3c807e047cb4abecf3f18eb68522f995b3b0f373681ef7d7730810d9ca'
     checksumType   = 'sha256'
-    checksum64     = 'd92cd8301ddc4db8715016f8d92f9d605aed693347323f32b6f23a70bf75a01d'
+    checksum64     = 'ff2d1b03da7feb24fb5de4ed7e9e09d574b4b29eea17edb11d7dee9233f0b2a4'
     checksumType64 = 'sha256'
 }
 

--- a/fusioninventory-agent/fusioninventory-agent.nuspec
+++ b/fusioninventory-agent/fusioninventory-agent.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent</id>
     <title>FusionInventory Agent</title>
-    <version>2.3.20</version>
+    <version>2.3.21</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -15,9 +15,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent/fusioninventory-agent-logo.png</iconUrl>
     <dependencies>
-      <dependency id="fusioninventory-agent.install" version="[2.3.20]" />
+      <dependency id="fusioninventory-agent.install" version="[2.3.21]" />
     </dependencies>
-    <releaseNotes>http://fusioninventory.org/2017/06/02/fusioninventory-agent-2.3.20.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2017/08/01/fusioninventory-agent-2.3.21.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>


### PR DESCRIPTION
This commit makes the package use FusionInventory Agent version 2.3.21.