### PR TITLE
Updated to use installer for v2.4.1

### DIFF
--- a/fusioninventory-agent.install/fusioninventory-agent.install.nuspec
+++ b/fusioninventory-agent.install/fusioninventory-agent.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent.install</id>
     <title>FusionInventory Agent (Install)</title>
-    <version>2.4</version>
+    <version>2.4.1</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/fusinv/fusioninventory-agent/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent.install/fusioninventory-agent-logo.png</iconUrl>
-    <releaseNotes>http://fusioninventory.org/2017/12/29/fusioninventory-agent-2.4.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2018/06/29/fusioninventory-agent-2.4.1.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>

--- a/fusioninventory-agent.install/tools/chocolateyInstall.ps1
+++ b/fusioninventory-agent.install/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
 $packageInstallArgs = @{
     packageName    = 'fusioninventory-agent.install'
     fileType       = 'exe'
-    url            = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4/fusioninventory-agent_windows-x86_2.4.exe'
-    url64bit       = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4/fusioninventory-agent_windows-x64_2.4.exe'
+    url            = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.1/fusioninventory-agent_windows-x86_2.4.1.exe'
+    url64bit       = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.1/fusioninventory-agent_windows-x64_2.4.1.exe'
     silentArgs     = '/S /acceptlicense'
     validExitCodes = @(0)
-    checksum       = '91796158da18bc53b11154ca9ac409b6915f9a7052caef5d671702ad2516ed32'
+    checksum       = '10987785b43496ee057aa1af57ec04e97b87962a23103835e79328652ce7ce4a'
     checksumType   = 'sha256'
-    checksum64     = '9a823580df4dd0cffa20d14c6266f1d05aeea789a4102f4026f98028912b49de'
+    checksum64     = '546a2e25bce5c5615dc32723be86effd464372801681bb644f4235e575598f77'
     checksumType64 = 'sha256'
 }
 

--- a/fusioninventory-agent.portable/fusioninventory-agent.portable.nuspec
+++ b/fusioninventory-agent.portable/fusioninventory-agent.portable.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent.portable</id>
     <title>FusionInventory Agent (Portable)</title>
-    <version>2.4</version>
+    <version>2.4.1</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/fusinv/fusioninventory-agent/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent.portable/fusioninventory-agent-logo.png</iconUrl>
-    <releaseNotes>http://fusioninventory.org/2017/12/29/fusioninventory-agent-2.4.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2018/06/29/fusioninventory-agent-2.4.1.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>

--- a/fusioninventory-agent.portable/tools/chocolateyInstall.ps1
+++ b/fusioninventory-agent.portable/tools/chocolateyInstall.ps1
@@ -4,11 +4,11 @@ $ErrorActionPreference = 'Stop'
 
 $packageDownloadArgs = @{
     packageName = $packageName
-    url         = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4/fusioninventory-agent_windows-x86_2.4-portable.exe' # NB: Theses EXE are 7z SFX
-    url64bit    = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4/fusioninventory-agent_windows-x64_2.4-portable.exe'
-    checksum       = '0abdcb03bcd27872bc88af21323904e05ee3ba9e3f6c434fccadef21a4f33d3b'
+    url         = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.1/fusioninventory-agent_windows-x86_2.4.1-portable.exe' # NB: Theses EXE are 7z SFX
+    url64bit    = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.1/fusioninventory-agent_windows-x64_2.4.1-portable.exe'
+    checksum       = 'd000b6d337c7ac9e2e6e23f5969de16ba0e702e419368346b256eee79525a4e8'
     checksumType   = 'sha256'
-    checksum64     = 'd5a79cec197a6cc63f27a77f4d30e23d062b484cf68fbd850bbcb68afaeb9049'
+    checksum64     = '1fa8d4b3b2d18ec86decd15e04ae0310d0332424d18abb26aae81e106565a1fc'
     checksumType64 = 'sha256'
 }
 

--- a/fusioninventory-agent/fusioninventory-agent.nuspec
+++ b/fusioninventory-agent/fusioninventory-agent.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent</id>
     <title>FusionInventory Agent</title>
-    <version>2.4</version>
+    <version>2.4.1</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -15,9 +15,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent/fusioninventory-agent-logo.png</iconUrl>
     <dependencies>
-      <dependency id="fusioninventory-agent.install" version="[2.4]" />
+      <dependency id="fusioninventory-agent.install" version="[2.4.1]" />
     </dependencies>
-    <releaseNotes>http://fusioninventory.org/2017/12/29/fusioninventory-agent-2.4.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2018/06/29/fusioninventory-agent-2.4.1.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>


### PR DESCRIPTION
This commit makes the package use FusionInventory Agent version 2.4.1.