### PR TITLE
Updated to use installer for v2.4.3

### DIFF
--- a/fusioninventory-agent.install/fusioninventory-agent.install.nuspec
+++ b/fusioninventory-agent.install/fusioninventory-agent.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent.install</id>
     <title>FusionInventory Agent (Install)</title>
-    <version>2.4.2</version>
+    <version>2.4.3</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/fusinv/fusioninventory-agent/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent.install/fusioninventory-agent-logo.png</iconUrl>
-    <releaseNotes>http://fusioninventory.org/2018/10/03/fusioninventory-agent-2.4.2.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2019/02/22/fusioninventory-agent-2.4.3.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>

--- a/fusioninventory-agent.install/tools/chocolateyInstall.ps1
+++ b/fusioninventory-agent.install/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
 $packageInstallArgs = @{
     packageName    = 'fusioninventory-agent.install'
     fileType       = 'exe'
-    url            = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.2/fusioninventory-agent_windows-x86_2.4.2.exe'
-    url64bit       = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.2/fusioninventory-agent_windows-x64_2.4.2.exe'
+    url            = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.3/fusioninventory-agent_windows-x86_2.4.3.exe'
+    url64bit       = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.3/fusioninventory-agent_windows-x64_2.4.3.exe'
     silentArgs     = '/S /acceptlicense'
     validExitCodes = @(0)
-    checksum       = '3f412487c068c952c0c9d630c1c9a4a20d054b338fb3bde64a21e3d8544bc5ca'
+    checksum       = '731c0185164bdb8863c433398f498ba575afda318db448310d4d7e79e187852b'
     checksumType   = 'sha256'
-    checksum64     = '10796ec2206f9f8970b117938fd82616cefbddcb996535c6b1ba74d9a54eb3fe'
+    checksum64     = 'f4e2c6e413bd8799c3fad36d1ca3ebc28800a0571e0a55a2866c99d0b6cb41c7'
     checksumType64 = 'sha256'
 }
 

--- a/fusioninventory-agent.portable/fusioninventory-agent.portable.nuspec
+++ b/fusioninventory-agent.portable/fusioninventory-agent.portable.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent.portable</id>
     <title>FusionInventory Agent (Portable)</title>
-    <version>2.4.2</version>
+    <version>2.4.3</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/fusinv/fusioninventory-agent/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent.portable/fusioninventory-agent-logo.png</iconUrl>
-    <releaseNotes>http://fusioninventory.org/2018/10/03/fusioninventory-agent-2.4.2.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2019/02/22/fusioninventory-agent-2.4.3.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>

--- a/fusioninventory-agent.portable/tools/chocolateyInstall.ps1
+++ b/fusioninventory-agent.portable/tools/chocolateyInstall.ps1
@@ -4,11 +4,11 @@ $ErrorActionPreference = 'Stop'
 
 $packageDownloadArgs = @{
     packageName = $packageName
-    url         = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.2/fusioninventory-agent_windows-x86_2.4.2-portable.exe' # NB: Theses EXE are 7z SFX
-    url64bit    = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.2/fusioninventory-agent_windows-x64_2.4.2-portable.exe'
-    checksum       = 'f9e08f1cc05f661ad2b8cc26dc13767d292fcbd4849d24cb5964def1607952d6'
+    url         = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.3/fusioninventory-agent_windows-x86_2.4.3-portable.exe' # NB: Theses EXE are 7z SFX
+    url64bit    = 'https://github.com/fusioninventory/fusioninventory-agent/releases/download/2.4.3/fusioninventory-agent_windows-x64_2.4.3-portable.exe'
+    checksum       = 'fa815fdf8a464f14371be33a188a8915027f7e4459f85b1218dd8919bb28621e'
     checksumType   = 'sha256'
-    checksum64     = '01e8f421a3cc5882ba4ceaddf53aabe44f5c8a7c2ab0ae5cf41d67a2984c3758'
+    checksum64     = '458643485edcf56b137e73c6823e197d9cdc069c12fad1af593153c057e036fc'
     checksumType64 = 'sha256'
 }
 

--- a/fusioninventory-agent/fusioninventory-agent.nuspec
+++ b/fusioninventory-agent/fusioninventory-agent.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>fusioninventory-agent</id>
     <title>FusionInventory Agent</title>
-    <version>2.4.2</version>
+    <version>2.4.3</version>
     <authors>FusionInventory Project</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>Agent for FusionInventory: performs a large array of management tasks, such as local inventory, software deployment or network discovery. It can be used either standalone, or in combination with a compatible server (OCS Inventory, GLPI, OTRS, Uranos, ...) acting as a centralized control point.</summary>
@@ -15,9 +15,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/C-Duv/chocolatey-fusioninventory-agent/master/fusioninventory-agent/fusioninventory-agent-logo.png</iconUrl>
     <dependencies>
-      <dependency id="fusioninventory-agent.install" version="[2.4.2]" />
+      <dependency id="fusioninventory-agent.install" version="[2.4.3]" />
     </dependencies>
-    <releaseNotes>http://fusioninventory.org/2018/10/03/fusioninventory-agent-2.4.2.html</releaseNotes>
+    <releaseNotes>http://fusioninventory.org/2019/02/22/fusioninventory-agent-2.4.3.html</releaseNotes>
     <projectSourceUrl>https://github.com/fusioninventory/fusioninventory-agent</projectSourceUrl>
     <bugTrackerUrl>https://github.com/fusioninventory/fusioninventory-agent/issues</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-fusioninventory-agent</packageSourceUrl>


### PR DESCRIPTION
This commit makes the package use FusionInventory Agent version 2.4.3.